### PR TITLE
Improve PhotoSwipe panel controls and collapsed overlay

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -96,6 +96,39 @@ html {
   right: calc(var(--pswp-right-strip-width, 0px) + 12px) !important;
 }
 
+.pswp-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  padding: 0.4rem 0.7rem;
+  border-radius: 0.75rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  background: rgba(15, 15, 15, 0.68);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: 0 8px 18px -10px rgba(0, 0, 0, 0.6);
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.pswp-btn:hover,
+.pswp-btn:focus {
+  background: rgba(15, 15, 15, 0.9);
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.pswp-btn:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.5);
+  outline-offset: 2px;
+}
+
+.pswp-btn:active {
+  transform: translateY(1px);
+}
+
 /* Filter transition animations */
 @keyframes filter-fade-scale-in {
   0% { opacity: 0; transform: scale(.95); }

--- a/src/components/galleries/GalleriesClient.tsx
+++ b/src/components/galleries/GalleriesClient.tsx
@@ -96,6 +96,7 @@ export default function GalleriesClient({ allImages, galleries }: { allImages: C
         open={open}
         index={index}
         onClose={() => setOpen(false)}
+        hidePanelBelow={640}
       />
     </div>
   );

--- a/src/components/sections/product-showcase.tsx
+++ b/src/components/sections/product-showcase.tsx
@@ -57,7 +57,14 @@ const PhotoLeftPanel: React.FC = () => {
 
   // Allow the global "Info" control inside the panel to flip the card
   useEffect(() => {
-    const onToggleInfo = () => setIsFlipped(s => !s);
+    const onToggleInfo = (event: Event) => {
+      const detail = (event as CustomEvent<{ collapsed?: boolean }>).detail;
+      if (detail && typeof detail.collapsed === 'boolean') {
+        setIsFlipped(detail.collapsed);
+      } else {
+        setIsFlipped(prev => !prev);
+      }
+    };
     window.addEventListener('pswp-toggle-info', onToggleInfo);
     return () => window.removeEventListener('pswp-toggle-info', onToggleInfo);
   }, []);


### PR DESCRIPTION
## Summary
- center PhotoSwipe media, add a visible info toggle, and propagate panel state changes
- render a flip-card overlay when the info panel is hidden while refreshing panel styling and controls
- update the All Galleries lightbox breakpoint and polish PhotoSwipe button styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cacecc0be4832ba682e0aacab1cc89