### PR TITLE
Ensure gallery lightbox collapse hides base media

### DIFF
--- a/src/components/ui/gallery-lightbox.tsx
+++ b/src/components/ui/gallery-lightbox.tsx
@@ -1460,7 +1460,7 @@ const GalleryLightbox: React.FC<GalleryLightboxProps> = ({ items, index = 0, ope
         try { updateUnderlyingMediaVisibility(); } catch {}
     };
 
-      // Hide underlying main media when collapsed (flipcard active) to avoid double view
+      // Hide underlying main media whenever the panel is collapsed so the flipcard is primary
       const updateUnderlyingMediaVisibility = () => {
         try {
           const pswpEl = getPswp(pswpRef)?.el;
@@ -1471,7 +1471,7 @@ const GalleryLightbox: React.FC<GalleryLightboxProps> = ({ items, index = 0, ope
             currentItem.querySelectorAll<HTMLElement>('img, video, .pswp__img, .pswp__zoom-wrap, .pswp__content')
           );
           if (!mediaTargets.length) return;
-          const hide = Boolean(panelCollapsed && flipCardFlipped);
+          const hide = Boolean(panelCollapsed);
           pswpEl.classList.toggle('pswp--flipcard-active', hide);
           mediaTargets.forEach((media) => {
             if (hide) {


### PR DESCRIPTION
## Summary
- hide the underlying PhotoSwipe media whenever the info panel is collapsed so the flipcard overlay is the primary focus
- update inline documentation to reflect the new collapse behaviour

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cb35415c80832bb380435d15557f88